### PR TITLE
Fix IEquatable implementation for FabricName

### DIFF
--- a/src/Microsoft.ServiceFabric.Common/FabricName.cs
+++ b/src/Microsoft.ServiceFabric.Common/FabricName.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="name1">The first object to compare.</param>
         /// <param name="name2">The second object to compare</param>
         /// <returns>true if name1 and name2 are equal; otherwise, false.</returns>
-        public static bool operator ==(FabricName name1, FabricName name2) => name1.Equals(name2);
+        public static bool operator ==(FabricName name1, FabricName name2) => name1 is null ? name2 is null : name1.Equals(name2);
 
         /// <summary>
         /// Indicates whether the values of two specified objects are not equal.
@@ -92,7 +92,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="name1">The first object to compare.</param>
         /// <param name="name2">The second object to compare</param>
         /// <returns>true if name1 and name2 are not equal; otherwise, false.</returns>
-        public static bool operator !=(FabricName name1, FabricName name2) => !name1.Equals(name2);
+        public static bool operator !=(FabricName name1, FabricName name2) => name1 is null ? !(name2 is null) : !name1.Equals(name2);
 
         /// <summary>
         /// Returns a string representation of the value of this instance.
@@ -105,14 +105,14 @@ namespace Microsoft.ServiceFabric.Common
         /// </summary>
         /// <param name="other">An object to compare to this instance.</param>
         /// <returns>true if this instance equal to other parameter; otherwise, false.</returns>
-        public bool Equals(FabricName other) => this.uri.Equals(other.uri);
+        public bool Equals(FabricName other) => this.uri.Equals(other?.uri);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object.
         /// </summary>
         /// <param name="other">The object to compare with this instance.</param>
         /// <returns>true if other object  has the same value as this instance; otherwise, false.</returns>
-        public override bool Equals(object other) => (other is FabricName) && this.uri.Equals(((FabricName)other).uri);
+        public override bool Equals(object other) => (other is FabricName) && this.uri.Equals(((FabricName)other)?.uri);
 
         /// <summary>
         /// Returns the hash code for this instance.


### PR DESCRIPTION
This bug causes null reference exception when creating service when calling fabricClient.Services.CreateServiceAsync API