### PR TITLE
Use ServiceFabricHttpClient for creating client

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -11,7 +11,7 @@ var sfClient = ServiceFabricClientFactory.Create(clusterUrl);
 // create client using security settings
 var clusterUrl = new Uri(@"https://<cluster_fqdn>:19080");
 var settings = new ClientSettings(GetSecurityCredentials);
-var sfClient = ServiceFabricClientFactory.Create(clusterUrl, settings);
+var sfClient = new ServiceFabricHttpClient(clusterUrl, settings);
 
 public static X509SecuritySettings GetSecurityCredentials()
 {
@@ -28,7 +28,7 @@ public static X509SecuritySettings GetSecurityCredentials()
 // create client using security settings
 var clusterUrl = new Uri(@"http:<luster_fqdn>19080");
 var settings = new ClientSettings(GetSecurityCredentials);
-var sfClient = ServiceFabricClientFactory.Create(clusterUrl, settings);
+var sfClient = new ServiceFabricHttpClient(clusterUrl, settings);
 
 static ClaimsSecuritySettings GetSecurityCredentials()
 {

--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ServiceFabric.Client.Http
 
             if (invalidClusterEndpoint != null)
             {
-                throw new ArgumentException(string.Format(SR.ErrorUrlScheme, invalidClusterEndpoint.Scheme.ToString(), scheme));
+                throw new ArgumentException(string.Format(SR.ErrorUrlScheme, invalidClusterEndpoint.Scheme, scheme));
             }
 
             if (delegateHandlers.Any(handler => handler == null))

--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ServiceFabric.Client.Http
 
             if (invalidClusterEndpoint != null)
             {
-                throw new ArgumentException(string.Format(SR.ErrorUrlScheme, invalidClusterEndpoint.Scheme, scheme));
+                throw new ArgumentException(string.Format(SR.ErrorUrlScheme, invalidClusterEndpoint.Scheme.ToString(), scheme));
             }
 
             if (delegateHandlers.Any(handler => handler == null))


### PR DESCRIPTION
ServiceFabricClientFactory uses reflection to create instance of ServiceFabricHttpClient so the correct reference of the http client is not added or checked during build in Visual Studio