### PR TITLE
Add error code to ServiceFabricException property

### DIFF
--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -351,7 +351,7 @@ namespace Microsoft.ServiceFabric.Client.Http
 
                 if (error != null)
                 {
-                    throw new ServiceFabricException($"{error.Error.Code.ToString()}. {error.Error.Message}");
+                    throw new ServiceFabricException(error.Message, error.ErrorCode ?? FabricErrorCodes.UNKNOWN, false);
                 }
             }
             else


### PR DESCRIPTION
Use correct ServiceFabricException constructor to add correct error code. Related to issue https://github.com/Microsoft/service-fabric-client-dotnet/issues/16