### PR TITLE
Library Usage: X509Certificate replaced by X509Certificate2

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -15,8 +15,8 @@ var sfClient = ServiceFabricClientFactory.Create(clusterUrl, settings);
 
 public static X509SecuritySettings GetSecurityCredentials()
 {
-    // get the X509Certificate either from Certificate store or from file.
-    var clientCert = new System.Security.Cryptography.X509Certificates.X509Certificate("<Path to .pfx file>", "password");
+    // get the X509Certificate2 either from Certificate store or from file.
+    var clientCert = new System.Security.Cryptography.X509Certificates.X509Certificate2("<Path to .pfx file>", "password");
     var remoteSecuritySettings = new RemoteX509SecuritySettings(new List<string> { "server_cert_thumbprint" });
     return new X509SecuritySettings(clientCert, remoteSecuritySettings);
 }


### PR DESCRIPTION
When I tried to use the sample provided in Library Usage file, I received a cast error. The right way is to use X509Certificate2 to connect with the cluster.