### PR TITLE
Fixed setting timeout after httpclient is created

### DIFF
--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -646,12 +646,13 @@ namespace Microsoft.ServiceFabric.Client.Http
                 }
             }
 
+            var httpClientInstance = new HttpClient(pipeline, true);
             if (this.ClientSettings?.ClientTimeout != null)
             {
-                this.httpClient.Timeout = (TimeSpan)this.ClientSettings.ClientTimeout;
+                httpClientInstance.Timeout = (TimeSpan)this.ClientSettings.ClientTimeout;
             }
 
-            return new HttpClient(pipeline, true);
+            return httpClientInstance;
         }
 
         private async Task InitializeBearerTokenHandlerAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
This code was giving a nullreference exception because the timeout was set on the class level variable that's not yet created.

Reproduce:
```
new ServiceFabricClientBuilder()
.UseEndpoints(sfUris)
.ConfigureClientSettings(c => c.ClientTimeout = TimeSpan.FromMinutes(1))
.BuildAsync();
```