### PR TITLE
Fix for issue#65 JsonReaderException raised from InfrastructureClient

### DIFF
--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/InfrastructureClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/InfrastructureClient.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ServiceFabric.Client.Http
                 return request;
             }
 
-            return this.httpClient.SendAsyncGetResponse(RequestFunc, url, JsonReaderExtensions.ReadValueAsString, requestId, cancellationToken);
+            return this.httpClient.SendAsyncGetResponseAsRawJson(RequestFunc, url, requestId, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -94,7 +94,7 @@ namespace Microsoft.ServiceFabric.Client.Http
                 return request;
             }
 
-            return this.httpClient.SendAsyncGetResponse(RequestFunc, url, JsonReaderExtensions.ReadValueAsString, requestId, cancellationToken);
+            return this.httpClient.SendAsyncGetResponseAsRawJson(RequestFunc, url, requestId, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -178,6 +178,36 @@ namespace Microsoft.ServiceFabric.Client.Http
         }
 
         /// <summary>
+        /// Sends an HTTP get request to cluster http gateway and returns the result as raw json.
+        /// </summary>
+        /// <param name="requestFunc">Func to create HttpRequest to send.</param>
+        /// <param name="relativeUri">The relative URI.</param>
+        /// <param name="requestId">Request Id for corelation</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The payload of the GET response as string.</returns>
+        /// <exception cref="ServiceFabricException">When the response is not a success.</exception>
+        internal async Task<string> SendAsyncGetResponseAsRawJson(
+            Func<HttpRequestMessage> requestFunc,
+            string relativeUri,
+            string requestId,
+            CancellationToken cancellationToken)
+        {
+            // pick a random Uri from endpoints(if more than 1) to send request to.
+            var endpoint = this.randomizedEndpoints.GetElement();
+            var requestUri = new Uri(endpoint, relativeUri);
+            var clientRequestId = this.GetClientRequestIdWithCorrelation(requestId);
+            var response = await this.SendAsyncHandleUnsuccessfulResponse(requestFunc, requestUri, clientRequestId, cancellationToken);
+            var retValue = default(string);
+
+            if (response != null && response.Content != null)
+            {
+                retValue = await response.Content.ReadAsStringAsync();
+            }
+
+            return retValue;
+        }
+
+        /// <summary>
         /// Sends an HTTP get request to cluster http gateway and deserializes the result.
         /// </summary>
         /// <typeparam name="T">The type of the response payload.</typeparam>


### PR DESCRIPTION
Adding a new method to ServiceFabricHttpClient to return raw json to handle strings returned by InfrastructureClient APIs.