### PR TITLE
Update IServiceFabricClient to implement IDisposable

### DIFF
--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ServiceFabric.Client.Http
         /// <summary>
         /// Disposes resources.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             this.Dispose(true);
         }

--- a/src/Microsoft.ServiceFabric.Client/IServiceFabricClient.cs
+++ b/src/Microsoft.ServiceFabric.Client/IServiceFabricClient.cs
@@ -5,10 +5,12 @@
 
 namespace Microsoft.ServiceFabric.Client
 {
+    using System;
+
     /// <summary>
     /// Interface for Service Fabric client.
     /// </summary>
-    public interface IServiceFabricClient
+    public interface IServiceFabricClient : IDisposable
     {
         /// <summary>
         /// Gets Application Client to performs management operations on applications.

--- a/src/Microsoft.ServiceFabric.Client/ServiceFabricClient.cs
+++ b/src/Microsoft.ServiceFabric.Client/ServiceFabricClient.cs
@@ -153,5 +153,8 @@ namespace Microsoft.ServiceFabric.Client
         /// </summary>
         /// <value>Cluster endpoint <see cref="System.Uri"/> .</value>
         protected IReadOnlyList<Uri> ClusterEndpoints { get; }
+
+        /// <inheritdoc/>
+        public abstract void Dispose();
     }
 }


### PR DESCRIPTION
As agreed over email, I'm updating IServiceFabricClient to implement IDisposable so that when the IServiceFabricClient object gets collected it does not leak the internal IDisposable objects like HttpClient.
(tracking issue [#74])