### PR TITLE
Exposing client timeout on Connect-SFCluster cmdlet, server timeout on Copy-SFApplicationPackage.

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -26,6 +26,5 @@
     <MinorVersion>1</MinorVersion>
     <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
-    <PreviewTag>-preview01</PreviewTag>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Client/Extensions/IImageStoreClient.cs
+++ b/src/Microsoft.ServiceFabric.Client/Extensions/IImageStoreClient.cs
@@ -102,6 +102,9 @@ namespace Microsoft.ServiceFabric.Client
         /// <param name="applicationPackagePathInImageStore">Relative path in the image store where the application package should be copied.
         /// If this is not specified, it defaults to the folder name as specified by applicationPackagePath.
         /// </param>
+        /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This specifies the time
+        /// duration that the client is willing to wait for the requested file upload operation for each chunk in the file to complete. The default value for this
+        /// parameter is 60 seconds.</param>
         /// <param name ="cancellationToken">Cancels the client-side operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="InvalidCredentialsException">Thrown when invalid credentials are used while making request to cluster.</exception>
@@ -112,6 +115,7 @@ namespace Microsoft.ServiceFabric.Client
             string applicationPackagePath,
             bool compressPackage = false,
             string applicationPackagePathInImageStore = default(string),
+            long? serverTimeout = 60,
             CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.ServiceFabric.Powershell.Http/ConnectClusterCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/ConnectClusterCmdlet.cs
@@ -121,6 +121,18 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         }
 
         /// <summary>
+        /// Gets or sets client timeout in seconds used by underlying http client to wait before the request times out. The default value for
+        /// this parameter is 90 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "Default")]
+        [Parameter(Mandatory = true,  ParameterSetName = "Windows")]
+        [Parameter(Mandatory = false, ParameterSetName = "X509_FindClientCert")]
+        [Parameter(Mandatory = false, ParameterSetName = "X509_ClientCertProvided")]
+        [Parameter(Mandatory = true,  ParameterSetName = "Aad")]
+        [Parameter(Mandatory = true,  ParameterSetName = "Dsts")]
+        public long? ClientTimeout { get; set; } = 90;
+
+        /// <summary>
         /// Gets or sets the switch to get Azure Active Directory metadata. When this switch is specified, Connect commandlet displays the Azure aCtive Directory metadata without validating the connection with AAD credentials.
         /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = "Aad")]
@@ -279,6 +291,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     (ct) => Task.FromResult<SecuritySettings>(new DstsClaimsSecuritySettings(CredentialsUtil.GetAccessTokenDstsAsync, remoteX509SecuritySettings));
 
                 builder.UseClaimsSecurity(securitySettings);
+            }
+
+            // set the client timeout.
+            if (this.ClientTimeout != null)
+            {
+                builder.ConfigureClientSettings(settings => settings.ClientTimeout = TimeSpan.FromSeconds(this.ClientTimeout.Value));
             }
 
             // build the client

--- a/src/Microsoft.ServiceFabric.Powershell.Http/CopyApplicationPackageCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/CopyApplicationPackageCmdlet.cs
@@ -34,12 +34,20 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             set;
         }
 
+        /// <summary>
+        /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public long? ServerTimeout { get; set; }
+
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
             try
             {
-                this.ServiceFabricClient.ImageStore.UploadApplicationPackageAsync(this.ApplicationPackagePath, false, this.ApplicationPackagePathInImageStore, this.CancellationToken).GetAwaiter().GetResult();
+                this.ServiceFabricClient.ImageStore.UploadApplicationPackageAsync(this.ApplicationPackagePath, false, this.ApplicationPackagePathInImageStore, this.ServerTimeout, this.CancellationToken).GetAwaiter().GetResult();
                 Console.WriteLine("Success!");
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes https://github.com/microsoft/service-fabric-client-dotnet/issues/87