### PR TITLE
Fix image store header

### DIFF
--- a/src/Microsoft.ServiceFabric.Client.Http/Extensions/ImageStoreClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Extensions/ImageStoreClient.cs
@@ -284,7 +284,6 @@ namespace Microsoft.ServiceFabric.Client.Http
                 request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
                 request.Content.Headers.ContentRange =
                     new ContentRangeHeaderValue(startBytePosition, endBytePosition, length);
-                request.Content.Headers.Add("Expect", "100-continue");
                 return request;
             }
 

--- a/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/ServiceFabricHttpClient.cs
@@ -701,6 +701,9 @@ namespace Microsoft.ServiceFabric.Client.Http
             }
 
             var httpClientInstance = new HttpClient(pipeline, true);
+
+            httpClientInstance.DefaultRequestHeaders.ExpectContinue = true;
+
             if (this.ClientSettings?.ClientTimeout != null)
             {
                 httpClientInstance.Timeout = (TimeSpan)this.ClientSettings.ClientTimeout;


### PR DESCRIPTION
Fix image store header. Removed the ("Expect", "100-continue") header from the content object and add ExpectContinue to the default request headers of the inner HttpClient instance. This is based on the original workaround Microsoft provided.