### PR TITLE
Enable secure NuGet.config in official builds

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,15 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
   <config>
-    <!--
-        Used to specify the default location to expand packages.
-        See: NuGet.exe help install
-        See: NuGet.exe help update
-    -->
     <add key="repositoryPath" value="nuget\restored_packages" />
   </config>
 </configuration>


### PR DESCRIPTION
Make NuGet.config use the default packageSources instead of clearing the inherited sources and defining the nuget.org feed explicitly. This allows GitHub builds to use the public NuGet.org feed, while the official builds use secure internal feeds instead.