### PR TITLE
Upgrade YamlDotNet.Signed package 5.2.1. to YamlDotNet 8.1.2

### DIFF
--- a/src/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-06" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0 " />
   </ItemGroup>  
   <ItemGroup>

--- a/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
+++ b/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />   
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(SourceCodeDir)Resource.resx">


### PR DESCRIPTION
Version 5.2.1 has been deprecated and no longer listed on NuGet.org. Version 8.1.2 is not the latest, but it's currently used by the rest of WindowsFabric. This package is used by the PowerShell module and not the NuGet packages built from this repo.