### PR TITLE
Change NodeLoadMetricInformation properties from int to double

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -22,8 +22,8 @@
 
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
-    <MajorVersion>4</MajorVersion>
-    <MinorVersion>12</MinorVersion>
+    <MajorVersion>5</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/NodeLoadMetricInformationConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/NodeLoadMetricInformationConverter.cs
@@ -40,10 +40,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var isCapacityViolation = default(bool?);
             var nodeBufferedCapacity = default(string);
             var nodeRemainingBufferedCapacity = default(string);
-            var currentNodeLoad = default(int?);
-            var nodeCapacityRemaining = default(int?);
-            var bufferedNodeCapacityRemaining = default(int?);
-            var plannedNodeLoadRemoval = default(int?);
+            var currentNodeLoad = default(double?);
+            var nodeCapacityRemaining = default(double?);
+            var bufferedNodeCapacityRemaining = default(double?);
+            var plannedNodeLoadRemoval = default(double?);
 
             do
             {
@@ -78,19 +78,19 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("CurrentNodeLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    currentNodeLoad = reader.ReadValueAsInt();
+                    currentNodeLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("NodeCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    nodeCapacityRemaining = reader.ReadValueAsInt();
+                    nodeCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("BufferedNodeCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    bufferedNodeCapacityRemaining = reader.ReadValueAsInt();
+                    bufferedNodeCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("PlannedNodeLoadRemoval", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    plannedNodeLoadRemoval = reader.ReadValueAsInt();
+                    plannedNodeLoadRemoval = reader.ReadValueAsDouble();
                 }
                 else
                 {
@@ -159,22 +159,22 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.CurrentNodeLoad != null)
             {
-                writer.WriteProperty(obj.CurrentNodeLoad, "CurrentNodeLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.CurrentNodeLoad, "CurrentNodeLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.NodeCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.NodeCapacityRemaining, "NodeCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.NodeCapacityRemaining, "NodeCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.BufferedNodeCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.BufferedNodeCapacityRemaining, "BufferedNodeCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.BufferedNodeCapacityRemaining, "BufferedNodeCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.PlannedNodeLoadRemoval != null)
             {
-                writer.WriteProperty(obj.PlannedNodeLoadRemoval, "PlannedNodeLoadRemoval", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.PlannedNodeLoadRemoval, "PlannedNodeLoadRemoval", JsonWriterExtensions.WriteDoubleValue);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.ServiceFabric.Common/Generated/NodeLoadMetricInformation.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/NodeLoadMetricInformation.cs
@@ -44,10 +44,10 @@ namespace Microsoft.ServiceFabric.Common
             bool? isCapacityViolation = default(bool?),
             string nodeBufferedCapacity = default(string),
             string nodeRemainingBufferedCapacity = default(string),
-            int? currentNodeLoad = default(int?),
-            int? nodeCapacityRemaining = default(int?),
-            int? bufferedNodeCapacityRemaining = default(int?),
-            int? plannedNodeLoadRemoval = default(int?))
+            double? currentNodeLoad = default(double?),
+            double? nodeCapacityRemaining = default(double?),
+            double? bufferedNodeCapacityRemaining = default(double?),
+            double? plannedNodeLoadRemoval = default(double?))
         {
             this.Name = name;
             this.NodeCapacity = nodeCapacity;
@@ -103,23 +103,23 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets current load on the node for this metric.
         /// </summary>
-        public int? CurrentNodeLoad { get; }
+        public double? CurrentNodeLoad { get; }
 
         /// <summary>
         /// Gets the remaining capacity on the node for the metric.
         /// </summary>
-        public int? NodeCapacityRemaining { get; }
+        public double? NodeCapacityRemaining { get; }
 
         /// <summary>
         /// Gets the remaining capacity which is not reserved by NodeBufferPercentage for this metric on the node.
         /// </summary>
-        public int? BufferedNodeCapacityRemaining { get; }
+        public double? BufferedNodeCapacityRemaining { get; }
 
         /// <summary>
         /// Gets this value represents the load of the replicas that are planned to be removed in the future.
         /// This kind of load is reported for replicas that are currently being moving to other nodes and for replicas that are
         /// currently being dropped but still use the load on the source node.
         /// </summary>
-        public int? PlannedNodeLoadRemoval { get; }
+        public double? PlannedNodeLoadRemoval { get; }
     }
 }


### PR DESCRIPTION
The following properties changed type from int to double because they were previously incorrectly defined in the swagger spec.
- currentNodeLoad
- nodeCapacityRemaining
- bufferedNodeCapacityRemaining
- plannedNodeLoadRemoval

Increment major package version because property type change is a breaking change.