### PR TITLE
Avoid overriding NuGetPackageVersion from environment variable

### DIFF
--- a/properties/service_fabric_nuget.props
+++ b/properties/service_fabric_nuget.props
@@ -4,7 +4,7 @@
 
   <!-- Set Versions. These are used for generating Nuget packages. -->
   <PropertyGroup>
-    <NuGetPackageVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion)$(PreviewTag)</NuGetPackageVersion>
+    <NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">$(MajorVersion).$(MinorVersion).$(BuildVersion)$(PreviewTag)</NuGetPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We need to allow `NuGetPackageVersion` to be provided as an environment variable. 
Currently, the value is unconditionally reassigned to values provided 
in `service_fabric_common.props`:

<img width="781" alt="propertyReassignment2" src="https://github.com/user-attachments/assets/0b7594f7-c75a-470a-b8ac-1bb40f15a9dd">

