### PR TITLE
Change LoadMetricInformation properties from int to double

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>0</BuildVersion>
+    <BuildVersion>1</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
@@ -38,26 +38,26 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var isBalancedAfter = default(bool?);
             var deviationBefore = default(double?);
             var deviationAfter = default(double?);
-            var balancingThreshold = default(int?);
+            var balancingThreshold = default(double?);
             var action = default(string);
             var activityThreshold = default(int?);
             var clusterCapacity = default(string);
             var clusterLoad = default(string);
-            var currentClusterLoad = default(int?);
+            var currentClusterLoad = default(double?);
             var clusterRemainingCapacity = default(string);
-            var clusterCapacityRemaining = default(int?);
+            var clusterCapacityRemaining = default(double?);
             var isClusterCapacityViolation = default(bool?);
-            var nodeBufferPercentage = default(int?);
+            var nodeBufferPercentage = default(double?);
             var clusterBufferedCapacity = default(string);
-            var bufferedClusterCapacityRemaining = default(int?);
+            var bufferedClusterCapacityRemaining = default(double?);
             var clusterRemainingBufferedCapacity = default(int?);
             var minNodeLoadValue = default(string);
-            var minimumNodeLoad = default(int?);
+            var minimumNodeLoad = default(double?);
             var minNodeLoadNodeId = default(NodeId);
             var maxNodeLoadValue = default(string);
-            var maximumNodeLoad = default(int?);
+            var maximumNodeLoad = default(double?);
             var maxNodeLoadNodeId = default(NodeId);
-            var plannedLoadRemoval = default(int?);
+            var plannedLoadRemoval = default(double?);
 
             do
             {
@@ -84,7 +84,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("BalancingThreshold", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    balancingThreshold = reader.ReadValueAsInt();
+                    balancingThreshold = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("Action", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -104,7 +104,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("CurrentClusterLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    currentClusterLoad = reader.ReadValueAsInt();
+                    currentClusterLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterRemainingCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -112,7 +112,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ClusterCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    clusterCapacityRemaining = reader.ReadValueAsInt();
+                    clusterCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("IsClusterCapacityViolation", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -120,7 +120,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("NodeBufferPercentage", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    nodeBufferPercentage = reader.ReadValueAsInt();
+                    nodeBufferPercentage = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -128,7 +128,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("BufferedClusterCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    bufferedClusterCapacityRemaining = reader.ReadValueAsInt();
+                    bufferedClusterCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterRemainingBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -140,7 +140,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("MinimumNodeLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    minimumNodeLoad = reader.ReadValueAsInt();
+                    minimumNodeLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("MinNodeLoadNodeId", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -152,7 +152,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("MaximumNodeLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    maximumNodeLoad = reader.ReadValueAsInt();
+                    maximumNodeLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("MaxNodeLoadNodeId", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -160,7 +160,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("PlannedLoadRemoval", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    plannedLoadRemoval = reader.ReadValueAsInt();
+                    plannedLoadRemoval = reader.ReadValueAsDouble();
                 }
                 else
                 {
@@ -233,7 +233,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.BalancingThreshold != null)
             {
-                writer.WriteProperty(obj.BalancingThreshold, "BalancingThreshold", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.BalancingThreshold, "BalancingThreshold", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.Action != null)
@@ -258,7 +258,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.CurrentClusterLoad != null)
             {
-                writer.WriteProperty(obj.CurrentClusterLoad, "CurrentClusterLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.CurrentClusterLoad, "CurrentClusterLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterRemainingCapacity != null)
@@ -268,7 +268,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ClusterCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.ClusterCapacityRemaining, "ClusterCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.ClusterCapacityRemaining, "ClusterCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.IsClusterCapacityViolation != null)
@@ -278,7 +278,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.NodeBufferPercentage != null)
             {
-                writer.WriteProperty(obj.NodeBufferPercentage, "NodeBufferPercentage", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.NodeBufferPercentage, "NodeBufferPercentage", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterBufferedCapacity != null)
@@ -288,7 +288,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.BufferedClusterCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.BufferedClusterCapacityRemaining, "BufferedClusterCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.BufferedClusterCapacityRemaining, "BufferedClusterCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterRemainingBufferedCapacity != null)
@@ -303,7 +303,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.MinimumNodeLoad != null)
             {
-                writer.WriteProperty(obj.MinimumNodeLoad, "MinimumNodeLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.MinimumNodeLoad, "MinimumNodeLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.MinNodeLoadNodeId != null)
@@ -318,7 +318,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.MaximumNodeLoad != null)
             {
-                writer.WriteProperty(obj.MaximumNodeLoad, "MaximumNodeLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.MaximumNodeLoad, "MaximumNodeLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.MaxNodeLoadNodeId != null)
@@ -328,7 +328,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.PlannedLoadRemoval != null)
             {
-                writer.WriteProperty(obj.PlannedLoadRemoval, "PlannedLoadRemoval", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.PlannedLoadRemoval, "PlannedLoadRemoval", JsonWriterExtensions.WriteDoubleValue);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
@@ -62,26 +62,26 @@ namespace Microsoft.ServiceFabric.Common
             bool? isBalancedAfter = default(bool?),
             double? deviationBefore = default(double?),
             double? deviationAfter = default(double?),
-            int? balancingThreshold = default(int?),
+            double? balancingThreshold = default(double?),
             string action = default(string),
             int? activityThreshold = default(int?),
             string clusterCapacity = default(string),
             string clusterLoad = default(string),
-            int? currentClusterLoad = default(int?),
+            double? currentClusterLoad = default(double?),
             string clusterRemainingCapacity = default(string),
-            int? clusterCapacityRemaining = default(int?),
+            double? clusterCapacityRemaining = default(double?),
             bool? isClusterCapacityViolation = default(bool?),
-            int? nodeBufferPercentage = default(int?),
+            double? nodeBufferPercentage = default(double?),
             string clusterBufferedCapacity = default(string),
-            int? bufferedClusterCapacityRemaining = default(int?),
+            double? bufferedClusterCapacityRemaining = default(double?),
             int? clusterRemainingBufferedCapacity = default(int?),
             string minNodeLoadValue = default(string),
-            int? minimumNodeLoad = default(int?),
+            double? minimumNodeLoad = default(double?),
             NodeId minNodeLoadNodeId = default(NodeId),
             string maxNodeLoadValue = default(string),
-            int? maximumNodeLoad = default(int?),
+            double? maximumNodeLoad = default(double?),
             NodeId maxNodeLoadNodeId = default(NodeId),
-            int? plannedLoadRemoval = default(int?))
+            double? plannedLoadRemoval = default(double?))
         {
             this.Name = name;
             this.IsBalancedBefore = isBalancedBefore;
@@ -138,7 +138,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the balancing threshold for a certain metric.
         /// </summary>
-        public int? BalancingThreshold { get; }
+        public double? BalancingThreshold { get; }
 
         /// <summary>
         /// Gets the current action being taken with regard to this metric
@@ -164,7 +164,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the total cluster load.
         /// </summary>
-        public int? CurrentClusterLoad { get; }
+        public double? CurrentClusterLoad { get; }
 
         /// <summary>
         /// Gets the remaining capacity for the metric in the cluster. In future releases of Service Fabric this parameter will
@@ -175,7 +175,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the remaining capacity for the metric in the cluster.
         /// </summary>
-        public int? ClusterCapacityRemaining { get; }
+        public double? ClusterCapacityRemaining { get; }
 
         /// <summary>
         /// Gets indicates that the metric is currently over capacity in the cluster.
@@ -185,7 +185,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the reserved percentage of total node capacity for this metric.
         /// </summary>
-        public int? NodeBufferPercentage { get; }
+        public double? NodeBufferPercentage { get; }
 
         /// <summary>
         /// Gets remaining capacity in the cluster excluding the reserved space. In future releases of Service Fabric this
@@ -196,7 +196,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets remaining capacity in the cluster excluding the reserved space.
         /// </summary>
-        public int? BufferedClusterCapacityRemaining { get; }
+        public double? BufferedClusterCapacityRemaining { get; }
 
         /// <summary>
         /// Gets the remaining percentage of cluster total capacity for this metric.
@@ -212,7 +212,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the minimum load on any node for this metric.
         /// </summary>
-        public int? MinimumNodeLoad { get; }
+        public double? MinimumNodeLoad { get; }
 
         /// <summary>
         /// Gets the node id of the node with the minimum load for this metric.
@@ -228,7 +228,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the maximum load on any node for this metric.
         /// </summary>
-        public int? MaximumNodeLoad { get; }
+        public double? MaximumNodeLoad { get; }
 
         /// <summary>
         /// Gets the node id of the node with the maximum load for this metric.
@@ -241,6 +241,6 @@ namespace Microsoft.ServiceFabric.Common
         /// This kind of load is reported for replicas that are currently being moving to other nodes and for replicas that are
         /// currently being dropped but still use the load on the source node.
         /// </summary>
-        public int? PlannedLoadRemoval { get; }
+        public double? PlannedLoadRemoval { get; }
     }
 }


### PR DESCRIPTION
The following properties changed type from int to double 
because they were previously incorrectly defined in the 
swagger spec.

* `balancingThreshold`
* `currentClusterLoad`
* `clusterCapacityRemaining`
* `nodeBufferPercentage`
* `bufferedClusterCapacityRemaining`
* `minimumNodeLoad`
* `maximumNodeLoad`
* `plannedLoadRemoval`

Property type change is in principle a breaking change. However,
previous version increment from `4.12.0` to `5.0.0` did not fix all
problems so it was not usable. In that sense, this is considered
a bugfix rather than a new major version (`6.0.0`).