### PR TITLE
Regenerate LoadMetricInformation with double properties

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>0</BuildVersion>
+    <BuildVersion>1</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
@@ -38,26 +38,26 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var isBalancedAfter = default(bool?);
             var deviationBefore = default(double?);
             var deviationAfter = default(double?);
-            var balancingThreshold = default(int?);
+            var balancingThreshold = default(double?);
             var action = default(string);
-            var activityThreshold = default(int?);
+            var activityThreshold = default(string);
             var clusterCapacity = default(string);
             var clusterLoad = default(string);
-            var currentClusterLoad = default(int?);
+            var currentClusterLoad = default(double?);
             var clusterRemainingCapacity = default(string);
-            var clusterCapacityRemaining = default(int?);
+            var clusterCapacityRemaining = default(double?);
             var isClusterCapacityViolation = default(bool?);
-            var nodeBufferPercentage = default(int?);
+            var nodeBufferPercentage = default(double?);
             var clusterBufferedCapacity = default(string);
-            var bufferedClusterCapacityRemaining = default(int?);
-            var clusterRemainingBufferedCapacity = default(int?);
+            var bufferedClusterCapacityRemaining = default(double?);
+            var clusterRemainingBufferedCapacity = default(string);
             var minNodeLoadValue = default(string);
-            var minimumNodeLoad = default(int?);
+            var minimumNodeLoad = default(double?);
             var minNodeLoadNodeId = default(NodeId);
             var maxNodeLoadValue = default(string);
-            var maximumNodeLoad = default(int?);
+            var maximumNodeLoad = default(double?);
             var maxNodeLoadNodeId = default(NodeId);
-            var plannedLoadRemoval = default(int?);
+            var plannedLoadRemoval = default(double?);
 
             do
             {
@@ -84,7 +84,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("BalancingThreshold", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    balancingThreshold = reader.ReadValueAsInt();
+                    balancingThreshold = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("Action", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -92,7 +92,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ActivityThreshold", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    activityThreshold = reader.ReadValueAsInt();
+                    activityThreshold = reader.ReadValueAsString();
                 }
                 else if (string.Compare("ClusterCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -104,7 +104,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("CurrentClusterLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    currentClusterLoad = reader.ReadValueAsInt();
+                    currentClusterLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterRemainingCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -112,7 +112,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ClusterCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    clusterCapacityRemaining = reader.ReadValueAsInt();
+                    clusterCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("IsClusterCapacityViolation", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -120,7 +120,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("NodeBufferPercentage", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    nodeBufferPercentage = reader.ReadValueAsInt();
+                    nodeBufferPercentage = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -128,11 +128,11 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("BufferedClusterCapacityRemaining", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    bufferedClusterCapacityRemaining = reader.ReadValueAsInt();
+                    bufferedClusterCapacityRemaining = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("ClusterRemainingBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    clusterRemainingBufferedCapacity = reader.ReadValueAsInt();
+                    clusterRemainingBufferedCapacity = reader.ReadValueAsString();
                 }
                 else if (string.Compare("MinNodeLoadValue", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -140,7 +140,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("MinimumNodeLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    minimumNodeLoad = reader.ReadValueAsInt();
+                    minimumNodeLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("MinNodeLoadNodeId", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -152,7 +152,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("MaximumNodeLoad", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    maximumNodeLoad = reader.ReadValueAsInt();
+                    maximumNodeLoad = reader.ReadValueAsDouble();
                 }
                 else if (string.Compare("MaxNodeLoadNodeId", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -160,7 +160,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("PlannedLoadRemoval", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    plannedLoadRemoval = reader.ReadValueAsInt();
+                    plannedLoadRemoval = reader.ReadValueAsDouble();
                 }
                 else
                 {
@@ -233,7 +233,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.BalancingThreshold != null)
             {
-                writer.WriteProperty(obj.BalancingThreshold, "BalancingThreshold", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.BalancingThreshold, "BalancingThreshold", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.Action != null)
@@ -243,7 +243,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ActivityThreshold != null)
             {
-                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteStringValue);
             }
 
             if (obj.ClusterCapacity != null)
@@ -258,7 +258,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.CurrentClusterLoad != null)
             {
-                writer.WriteProperty(obj.CurrentClusterLoad, "CurrentClusterLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.CurrentClusterLoad, "CurrentClusterLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterRemainingCapacity != null)
@@ -268,7 +268,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ClusterCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.ClusterCapacityRemaining, "ClusterCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.ClusterCapacityRemaining, "ClusterCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.IsClusterCapacityViolation != null)
@@ -278,7 +278,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.NodeBufferPercentage != null)
             {
-                writer.WriteProperty(obj.NodeBufferPercentage, "NodeBufferPercentage", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.NodeBufferPercentage, "NodeBufferPercentage", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterBufferedCapacity != null)
@@ -288,12 +288,12 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.BufferedClusterCapacityRemaining != null)
             {
-                writer.WriteProperty(obj.BufferedClusterCapacityRemaining, "BufferedClusterCapacityRemaining", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.BufferedClusterCapacityRemaining, "BufferedClusterCapacityRemaining", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.ClusterRemainingBufferedCapacity != null)
             {
-                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteStringValue);
             }
 
             if (obj.MinNodeLoadValue != null)
@@ -303,7 +303,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.MinimumNodeLoad != null)
             {
-                writer.WriteProperty(obj.MinimumNodeLoad, "MinimumNodeLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.MinimumNodeLoad, "MinimumNodeLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.MinNodeLoadNodeId != null)
@@ -318,7 +318,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.MaximumNodeLoad != null)
             {
-                writer.WriteProperty(obj.MaximumNodeLoad, "MaximumNodeLoad", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.MaximumNodeLoad, "MaximumNodeLoad", JsonWriterExtensions.WriteDoubleValue);
             }
 
             if (obj.MaxNodeLoadNodeId != null)
@@ -328,7 +328,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.PlannedLoadRemoval != null)
             {
-                writer.WriteProperty(obj.PlannedLoadRemoval, "PlannedLoadRemoval", JsonWriterExtensions.WriteIntValue);
+                writer.WriteProperty(obj.PlannedLoadRemoval, "PlannedLoadRemoval", JsonWriterExtensions.WriteDoubleValue);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var deviationAfter = default(double?);
             var balancingThreshold = default(double?);
             var action = default(string);
-            var activityThreshold = default(long?);
+            var activityThreshold = default(string);
             var clusterCapacity = default(string);
             var clusterLoad = default(string);
             var currentClusterLoad = default(double?);
@@ -50,7 +50,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var nodeBufferPercentage = default(double?);
             var clusterBufferedCapacity = default(string);
             var bufferedClusterCapacityRemaining = default(double?);
-            var clusterRemainingBufferedCapacity = default(long?);
+            var clusterRemainingBufferedCapacity = default(string);
             var minNodeLoadValue = default(string);
             var minimumNodeLoad = default(double?);
             var minNodeLoadNodeId = default(NodeId);
@@ -92,7 +92,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ActivityThreshold", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    activityThreshold = reader.ReadValueAsLong();
+                    activityThreshold = reader.ReadValueAsString();
                 }
                 else if (string.Compare("ClusterCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ClusterRemainingBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    clusterRemainingBufferedCapacity = reader.ReadValueAsLong();
+                    clusterRemainingBufferedCapacity = reader.ReadValueAsString();
                 }
                 else if (string.Compare("MinNodeLoadValue", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -243,7 +243,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ActivityThreshold != null)
             {
-                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteLongValue);
+                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteStringValue);
             }
 
             if (obj.ClusterCapacity != null)
@@ -293,7 +293,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ClusterRemainingBufferedCapacity != null)
             {
-                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteLongValue);
+                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteStringValue);
             }
 
             if (obj.MinNodeLoadValue != null)

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/LoadMetricInformationConverter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var deviationAfter = default(double?);
             var balancingThreshold = default(double?);
             var action = default(string);
-            var activityThreshold = default(string);
+            var activityThreshold = default(long?);
             var clusterCapacity = default(string);
             var clusterLoad = default(string);
             var currentClusterLoad = default(double?);
@@ -50,7 +50,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var nodeBufferPercentage = default(double?);
             var clusterBufferedCapacity = default(string);
             var bufferedClusterCapacityRemaining = default(double?);
-            var clusterRemainingBufferedCapacity = default(string);
+            var clusterRemainingBufferedCapacity = default(long?);
             var minNodeLoadValue = default(string);
             var minimumNodeLoad = default(double?);
             var minNodeLoadNodeId = default(NodeId);
@@ -92,7 +92,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ActivityThreshold", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    activityThreshold = reader.ReadValueAsString();
+                    activityThreshold = reader.ReadValueAsLong();
                 }
                 else if (string.Compare("ClusterCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 }
                 else if (string.Compare("ClusterRemainingBufferedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    clusterRemainingBufferedCapacity = reader.ReadValueAsString();
+                    clusterRemainingBufferedCapacity = reader.ReadValueAsLong();
                 }
                 else if (string.Compare("MinNodeLoadValue", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -243,7 +243,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ActivityThreshold != null)
             {
-                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteStringValue);
+                writer.WriteProperty(obj.ActivityThreshold, "ActivityThreshold", JsonWriterExtensions.WriteLongValue);
             }
 
             if (obj.ClusterCapacity != null)
@@ -293,7 +293,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             if (obj.ClusterRemainingBufferedCapacity != null)
             {
-                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteStringValue);
+                writer.WriteProperty(obj.ClusterRemainingBufferedCapacity, "ClusterRemainingBufferedCapacity", JsonWriterExtensions.WriteLongValue);
             }
 
             if (obj.MinNodeLoadValue != null)

--- a/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
@@ -62,26 +62,26 @@ namespace Microsoft.ServiceFabric.Common
             bool? isBalancedAfter = default(bool?),
             double? deviationBefore = default(double?),
             double? deviationAfter = default(double?),
-            int? balancingThreshold = default(int?),
+            double? balancingThreshold = default(double?),
             string action = default(string),
-            int? activityThreshold = default(int?),
+            string activityThreshold = default(string),
             string clusterCapacity = default(string),
             string clusterLoad = default(string),
-            int? currentClusterLoad = default(int?),
+            double? currentClusterLoad = default(double?),
             string clusterRemainingCapacity = default(string),
-            int? clusterCapacityRemaining = default(int?),
+            double? clusterCapacityRemaining = default(double?),
             bool? isClusterCapacityViolation = default(bool?),
-            int? nodeBufferPercentage = default(int?),
+            double? nodeBufferPercentage = default(double?),
             string clusterBufferedCapacity = default(string),
-            int? bufferedClusterCapacityRemaining = default(int?),
-            int? clusterRemainingBufferedCapacity = default(int?),
+            double? bufferedClusterCapacityRemaining = default(double?),
+            string clusterRemainingBufferedCapacity = default(string),
             string minNodeLoadValue = default(string),
-            int? minimumNodeLoad = default(int?),
+            double? minimumNodeLoad = default(double?),
             NodeId minNodeLoadNodeId = default(NodeId),
             string maxNodeLoadValue = default(string),
-            int? maximumNodeLoad = default(int?),
+            double? maximumNodeLoad = default(double?),
             NodeId maxNodeLoadNodeId = default(NodeId),
-            int? plannedLoadRemoval = default(int?))
+            double? plannedLoadRemoval = default(double?))
         {
             this.Name = name;
             this.IsBalancedBefore = isBalancedBefore;
@@ -138,7 +138,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the balancing threshold for a certain metric.
         /// </summary>
-        public int? BalancingThreshold { get; }
+        public double? BalancingThreshold { get; }
 
         /// <summary>
         /// Gets the current action being taken with regard to this metric
@@ -148,7 +148,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the Activity Threshold specified for this metric in the system Cluster Manifest.
         /// </summary>
-        public int? ActivityThreshold { get; }
+        public string ActivityThreshold { get; }
 
         /// <summary>
         /// Gets the total cluster capacity for a given metric
@@ -164,7 +164,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the total cluster load.
         /// </summary>
-        public int? CurrentClusterLoad { get; }
+        public double? CurrentClusterLoad { get; }
 
         /// <summary>
         /// Gets the remaining capacity for the metric in the cluster. In future releases of Service Fabric this parameter will
@@ -175,7 +175,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the remaining capacity for the metric in the cluster.
         /// </summary>
-        public int? ClusterCapacityRemaining { get; }
+        public double? ClusterCapacityRemaining { get; }
 
         /// <summary>
         /// Gets indicates that the metric is currently over capacity in the cluster.
@@ -185,7 +185,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the reserved percentage of total node capacity for this metric.
         /// </summary>
-        public int? NodeBufferPercentage { get; }
+        public double? NodeBufferPercentage { get; }
 
         /// <summary>
         /// Gets remaining capacity in the cluster excluding the reserved space. In future releases of Service Fabric this
@@ -196,12 +196,12 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets remaining capacity in the cluster excluding the reserved space.
         /// </summary>
-        public int? BufferedClusterCapacityRemaining { get; }
+        public double? BufferedClusterCapacityRemaining { get; }
 
         /// <summary>
         /// Gets the remaining percentage of cluster total capacity for this metric.
         /// </summary>
-        public int? ClusterRemainingBufferedCapacity { get; }
+        public string ClusterRemainingBufferedCapacity { get; }
 
         /// <summary>
         /// Gets the minimum load on any node for this metric. In future releases of Service Fabric this parameter will be
@@ -212,7 +212,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the minimum load on any node for this metric.
         /// </summary>
-        public int? MinimumNodeLoad { get; }
+        public double? MinimumNodeLoad { get; }
 
         /// <summary>
         /// Gets the node id of the node with the minimum load for this metric.
@@ -228,7 +228,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the maximum load on any node for this metric.
         /// </summary>
-        public int? MaximumNodeLoad { get; }
+        public double? MaximumNodeLoad { get; }
 
         /// <summary>
         /// Gets the node id of the node with the maximum load for this metric.
@@ -241,6 +241,6 @@ namespace Microsoft.ServiceFabric.Common
         /// This kind of load is reported for replicas that are currently being moving to other nodes and for replicas that are
         /// currently being dropped but still use the load on the source node.
         /// </summary>
-        public int? PlannedLoadRemoval { get; }
+        public double? PlannedLoadRemoval { get; }
     }
 }

--- a/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ServiceFabric.Common
             double? deviationAfter = default(double?),
             double? balancingThreshold = default(double?),
             string action = default(string),
-            string activityThreshold = default(string),
+            long? activityThreshold = default(long?),
             string clusterCapacity = default(string),
             string clusterLoad = default(string),
             double? currentClusterLoad = default(double?),
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Common
             double? nodeBufferPercentage = default(double?),
             string clusterBufferedCapacity = default(string),
             double? bufferedClusterCapacityRemaining = default(double?),
-            string clusterRemainingBufferedCapacity = default(string),
+            long? clusterRemainingBufferedCapacity = default(long?),
             string minNodeLoadValue = default(string),
             double? minimumNodeLoad = default(double?),
             NodeId minNodeLoadNodeId = default(NodeId),
@@ -148,7 +148,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the Activity Threshold specified for this metric in the system Cluster Manifest.
         /// </summary>
-        public string ActivityThreshold { get; }
+        public long? ActivityThreshold { get; }
 
         /// <summary>
         /// Gets the total cluster capacity for a given metric
@@ -201,7 +201,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the remaining percentage of cluster total capacity for this metric.
         /// </summary>
-        public string ClusterRemainingBufferedCapacity { get; }
+        public long? ClusterRemainingBufferedCapacity { get; }
 
         /// <summary>
         /// Gets the minimum load on any node for this metric. In future releases of Service Fabric this parameter will be

--- a/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/LoadMetricInformation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ServiceFabric.Common
             double? deviationAfter = default(double?),
             double? balancingThreshold = default(double?),
             string action = default(string),
-            long? activityThreshold = default(long?),
+            string activityThreshold = default(string),
             string clusterCapacity = default(string),
             string clusterLoad = default(string),
             double? currentClusterLoad = default(double?),
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Common
             double? nodeBufferPercentage = default(double?),
             string clusterBufferedCapacity = default(string),
             double? bufferedClusterCapacityRemaining = default(double?),
-            long? clusterRemainingBufferedCapacity = default(long?),
+            string clusterRemainingBufferedCapacity = default(string),
             string minNodeLoadValue = default(string),
             double? minimumNodeLoad = default(double?),
             NodeId minNodeLoadNodeId = default(NodeId),
@@ -148,7 +148,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the Activity Threshold specified for this metric in the system Cluster Manifest.
         /// </summary>
-        public long? ActivityThreshold { get; }
+        public string ActivityThreshold { get; }
 
         /// <summary>
         /// Gets the total cluster capacity for a given metric
@@ -201,7 +201,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the remaining percentage of cluster total capacity for this metric.
         /// </summary>
-        public long? ClusterRemainingBufferedCapacity { get; }
+        public string ClusterRemainingBufferedCapacity { get; }
 
         /// <summary>
         /// Gets the minimum load on any node for this metric. In future releases of Service Fabric this parameter will be

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/ValidateClusterUpgradeCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/ValidateClusterUpgradeCmdlet.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
     /// <summary>
     /// Validate and assess the impact of a code or configuration version update of a Service Fabric cluster.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Confirm, "SFClusterUpgrade")]
+    [Cmdlet(VerbsCommon.Validate, "SFClusterUpgrade")]
     public partial class ValidateClusterUpgradeCmdlet : CommonCmdletBase
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/ValidateClusterUpgradeCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/ValidateClusterUpgradeCmdlet.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
     /// <summary>
     /// Validate and assess the impact of a code or configuration version update of a Service Fabric cluster.
     /// </summary>
-    [Cmdlet(VerbsCommon.Validate, "SFClusterUpgrade")]
+    [Cmdlet(VerbsLifecycle.Confirm, "SFClusterUpgrade")]
     public partial class ValidateClusterUpgradeCmdlet : CommonCmdletBase
     {
         /// <summary>


### PR DESCRIPTION
The following properties changed type because they 
were previously incorrectly defined in the swagger spec:

`balancingThreshold`: `int` -> `double`
`activityThreshold`: `int` -> `string`
`currentClusterLoad`: `int` -> `double`
`clusterCapacityRemaining`: `int` -> `double`
`nodeBufferPercentage`: `int` -> `double`
`bufferedClusterCapacityRemaining`: `int` -> `double`
`clusterRemainingBufferedCapacity`: `int` -> `string`
`minimumNodeLoad`: `int` -> `double`
`maximumNodeLoad`: `int` -> `double`
`plannedLoadRemoval`: `int` -> `double`

Property type change is in principle a breaking change. However,
previous version increment from `4.12.0` to `5.0.0` did not fix all
problems so it was not usable. In that sense, this is considered
a bugfix rather than a new major version (`6.0.0`).