### PR TITLE
Add compression, restore state, and metadata flag in BackupRestoreService

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -23,7 +23,7 @@
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>5</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <BuildVersion>1</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>5</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <BuildVersion>1</BuildVersion>
+    <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/BackupRestoreClient.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/BackupRestoreClient.cs
@@ -372,6 +372,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             DateTime? endDateTimeFilter = default(DateTime?),
             ContinuationToken continuationToken = default(ContinuationToken),
             long? maxResults = 0,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             applicationId.ThrowIfNull(nameof(applicationId));
@@ -389,6 +390,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             endDateTimeFilter?.AddToQueryParameters(queryParams, $"EndDateTimeFilter={System.Xml.XmlConvert.ToString(endDateTimeFilter.Value, System.Xml.XmlDateTimeSerializationMode.Utc).ToString()}");
             continuationToken?.AddToQueryParameters(queryParams, $"ContinuationToken={continuationToken.ToString()}");
             maxResults?.AddToQueryParameters(queryParams, $"MaxResults={maxResults}");
+            metadataFromBlob?.AddToQueryParameters(queryParams, $"MetadataFromBlob={metadataFromBlob}");
             queryParams.Add("api-version=6.4");
             url += "?" + string.Join("&", queryParams);
             
@@ -593,6 +595,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             DateTime? endDateTimeFilter = default(DateTime?),
             ContinuationToken continuationToken = default(ContinuationToken),
             long? maxResults = 0,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             serviceId.ThrowIfNull(nameof(serviceId));
@@ -610,6 +613,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             endDateTimeFilter?.AddToQueryParameters(queryParams, $"EndDateTimeFilter={System.Xml.XmlConvert.ToString(endDateTimeFilter.Value, System.Xml.XmlDateTimeSerializationMode.Utc).ToString()}");
             continuationToken?.AddToQueryParameters(queryParams, $"ContinuationToken={continuationToken.ToString()}");
             maxResults?.AddToQueryParameters(queryParams, $"MaxResults={maxResults}");
+            metadataFromBlob?.AddToQueryParameters(queryParams, $"MetadataFromBlob={metadataFromBlob}");
             queryParams.Add("api-version=6.4");
             url += "?" + string.Join("&", queryParams);
             
@@ -807,6 +811,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             bool? latest = false,
             DateTime? startDateTimeFilter = default(DateTime?),
             DateTime? endDateTimeFilter = default(DateTime?),
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             partitionId.ThrowIfNull(nameof(partitionId));
@@ -821,6 +826,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             latest?.AddToQueryParameters(queryParams, $"Latest={latest}");
             startDateTimeFilter?.AddToQueryParameters(queryParams, $"StartDateTimeFilter={System.Xml.XmlConvert.ToString(startDateTimeFilter.Value, System.Xml.XmlDateTimeSerializationMode.Utc).ToString()}");
             endDateTimeFilter?.AddToQueryParameters(queryParams, $"EndDateTimeFilter={System.Xml.XmlConvert.ToString(endDateTimeFilter.Value, System.Xml.XmlDateTimeSerializationMode.Utc).ToString()}");
+            metadataFromBlob?.AddToQueryParameters(queryParams, $"MetadataFromBlob={metadataFromBlob}");
             queryParams.Add("api-version=6.4");
             url += "?" + string.Join("&", queryParams);
             
@@ -979,6 +985,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             bool? latest = false,
             int? restoreTimeout = 10,
             long? serverTimeout = 60,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             partitionId.ThrowIfNull(nameof(partitionId));
@@ -992,6 +999,7 @@ namespace Microsoft.ServiceFabric.Client.Http
             latest?.AddToQueryParameters(queryParams, $"Latest={latest}");
             restoreTimeout?.AddToQueryParameters(queryParams, $"RestoreTimeout={restoreTimeout}");
             serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
+            metadataFromBlob?.AddToQueryParameters(queryParams, $"MetadataFromBlob={metadataFromBlob}");
             queryParams.Add("api-version=6.4");
             url += "?" + string.Join("&", queryParams);
             

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/BackupPolicyDescriptionConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/BackupPolicyDescriptionConverter.cs
@@ -39,8 +39,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var schedule = default(BackupScheduleDescription);
             var storage = default(BackupStorageDescription);
             var retentionPolicy = default(RetentionPolicyDescription);
-            var compressionStrategy = default(CompressionStrategy?);
-            var quickRecovery = default(bool?);
+            var compressionType = default(CompressionType?);
+            var quickRecovery = default(QuickRecovery?);
 
             do
             {
@@ -69,13 +69,13 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     retentionPolicy = RetentionPolicyDescriptionConverter.Deserialize(reader);
                 }
-                else if (string.Compare("CompressionStrategy", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("CompressionType", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    compressionStrategy = CompressionStrategyConverter.Deserialize(reader);
+                    compressionType = CompressionTypeConverter.Deserialize(reader);
                 }
                 else if (string.Compare("QuickRecovery", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    quickRecovery = reader.ReadValueAsBool();
+                    quickRecovery = QuickRecoveryConverter.Deserialize(reader);
                 }
                 else
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 schedule: schedule,
                 storage: storage,
                 retentionPolicy: retentionPolicy,
-                compressionStrategy: compressionStrategy,
+                compressionType: compressionType,
                 quickRecovery: quickRecovery);
         }
 
@@ -109,15 +109,11 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.MaxIncrementalBackups, "MaxIncrementalBackups", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.Schedule, "Schedule", BackupScheduleDescriptionConverter.Serialize);
             writer.WriteProperty(obj.Storage, "Storage", BackupStorageDescriptionConverter.Serialize);
-            writer.WriteProperty(obj.CompressionStrategy, "CompressionStrategy", CompressionStrategyConverter.Serialize);
+            writer.WriteProperty(obj.CompressionType, "CompressionType", CompressionTypeConverter.Serialize);
+            writer.WriteProperty(obj.QuickRecovery, "QuickRecovery", QuickRecoveryConverter.Serialize);
             if (obj.RetentionPolicy != null)
             {
                 writer.WriteProperty(obj.RetentionPolicy, "RetentionPolicy", RetentionPolicyDescriptionConverter.Serialize);
-            }
-
-            if (obj.QuickRecovery != null)
-            {
-                writer.WriteProperty(obj.QuickRecovery, "QuickRecovery", JsonWriterExtensions.WriteBoolValue);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/BackupPolicyDescriptionConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/BackupPolicyDescriptionConverter.cs
@@ -39,6 +39,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var schedule = default(BackupScheduleDescription);
             var storage = default(BackupStorageDescription);
             var retentionPolicy = default(RetentionPolicyDescription);
+            var compressionStrategy = default(CompressionStrategy?);
+            var quickRecovery = default(bool?);
 
             do
             {
@@ -67,6 +69,14 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     retentionPolicy = RetentionPolicyDescriptionConverter.Deserialize(reader);
                 }
+                else if (string.Compare("CompressionStrategy", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    compressionStrategy = CompressionStrategyConverter.Deserialize(reader);
+                }
+                else if (string.Compare("QuickRecovery", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    quickRecovery = reader.ReadValueAsBool();
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -80,7 +90,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 maxIncrementalBackups: maxIncrementalBackups,
                 schedule: schedule,
                 storage: storage,
-                retentionPolicy: retentionPolicy);
+                retentionPolicy: retentionPolicy,
+                compressionStrategy: compressionStrategy,
+                quickRecovery: quickRecovery);
         }
 
         /// <summary>
@@ -97,9 +109,15 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.MaxIncrementalBackups, "MaxIncrementalBackups", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.Schedule, "Schedule", BackupScheduleDescriptionConverter.Serialize);
             writer.WriteProperty(obj.Storage, "Storage", BackupStorageDescriptionConverter.Serialize);
+            writer.WriteProperty(obj.CompressionStrategy, "CompressionStrategy", CompressionStrategyConverter.Serialize);
             if (obj.RetentionPolicy != null)
             {
                 writer.WriteProperty(obj.RetentionPolicy, "RetentionPolicy", RetentionPolicyDescriptionConverter.Serialize);
+            }
+
+            if (obj.QuickRecovery != null)
+            {
+                writer.WriteProperty(obj.QuickRecovery, "QuickRecovery", JsonWriterExtensions.WriteBoolValue);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/CompressionStrategyConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/CompressionStrategyConverter.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CompressionStrategy" />.
+    /// </summary>
+    internal class CompressionStrategyConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static CompressionStrategy? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(CompressionStrategy);
+
+            if (string.Compare(value, "ZIP", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CompressionStrategy.ZIP;
+            }
+            else if (string.Compare(value, "ZSTANDARD", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CompressionStrategy.ZSTANDARD;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, CompressionStrategy? value)
+        {
+            switch (value)
+            {
+                case CompressionStrategy.ZIP:
+                    writer.WriteStringValue("ZIP");
+                    break;
+                case CompressionStrategy.ZSTANDARD:
+                    writer.WriteStringValue("ZSTANDARD");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type CompressionStrategy");
+            }
+        }
+    }
+}

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/CompressionTypeConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/CompressionTypeConverter.cs
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CompressionType" />.
+    /// </summary>
+    internal class CompressionTypeConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static CompressionType? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(CompressionType);
+
+            if (string.Compare(value, "CLUSTER_DEFINED", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CompressionType.CLUSTER_DEFINED;
+            }
+            else if (string.Compare(value, "ZIP", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CompressionType.ZIP;
+            }
+            else if (string.Compare(value, "ZSTANDARD", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CompressionType.ZSTANDARD;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, CompressionType? value)
+        {
+            switch (value)
+            {
+                case CompressionType.CLUSTER_DEFINED:
+                    writer.WriteStringValue("CLUSTER_DEFINED");
+                    break;
+                case CompressionType.ZIP:
+                    writer.WriteStringValue("ZIP");
+                    break;
+                case CompressionType.ZSTANDARD:
+                    writer.WriteStringValue("ZSTANDARD");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type CompressionType");
+            }
+        }
+    }
+}

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/QuickRecoveryConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/QuickRecoveryConverter.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="QuickRecovery" />.
+    /// </summary>
+    internal class QuickRecoveryConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static QuickRecovery? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(QuickRecovery);
+
+            if (string.Compare(value, "Disabled", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = QuickRecovery.Disabled;
+            }
+            else if (string.Compare(value, "FromPrimary", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = QuickRecovery.FromPrimary;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, QuickRecovery? value)
+        {
+            switch (value)
+            {
+                case QuickRecovery.Disabled:
+                    writer.WriteStringValue("Disabled");
+                    break;
+                case QuickRecovery.FromPrimary:
+                    writer.WriteStringValue("FromPrimary");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type QuickRecovery");
+            }
+        }
+    }
+}

--- a/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/RestoreStateConverter.cs
+++ b/src/Microsoft.ServiceFabric.Client.Http/Generated/Serialization/RestoreStateConverter.cs
@@ -38,6 +38,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             {
                 obj = RestoreState.RestoreInProgress;
             }
+            else if (string.Compare(value, "SecondariesInProgress", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = RestoreState.SecondariesInProgress;
+            }
             else if (string.Compare(value, "Success", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 obj = RestoreState.Success;
@@ -71,6 +75,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                     break;
                 case RestoreState.RestoreInProgress:
                     writer.WriteStringValue("RestoreInProgress");
+                    break;
+                case RestoreState.SecondariesInProgress:
+                    writer.WriteStringValue("SecondariesInProgress");
                     break;
                 case RestoreState.Success:
                     writer.WriteStringValue("Success");

--- a/src/Microsoft.ServiceFabric.Client/Generated/IBackupRestoreClient.cs
+++ b/src/Microsoft.ServiceFabric.Client/Generated/IBackupRestoreClient.cs
@@ -311,6 +311,8 @@ namespace Microsoft.ServiceFabric.Client
         /// maximum results if they do not fit in the message as per the max message size restrictions defined in the
         /// configuration. If this parameter is zero or not specified, the paged query includes as many results as possible
         /// that fit in the return message.</param>
+        /// <param name ="metadataFromBlob">Specifies whether to fetch backup metadata from the backup blob in the
+        /// response.</param>
         /// <param name ="cancellationToken">Cancels the client-side operation.</param>
         /// <returns>
         /// A task that represents the asynchronous operation.
@@ -327,6 +329,7 @@ namespace Microsoft.ServiceFabric.Client
             DateTime? endDateTimeFilter = default(DateTime?),
             ContinuationToken continuationToken = default(ContinuationToken),
             long? maxResults = 0,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -522,6 +525,8 @@ namespace Microsoft.ServiceFabric.Client
         /// maximum results if they do not fit in the message as per the max message size restrictions defined in the
         /// configuration. If this parameter is zero or not specified, the paged query includes as many results as possible
         /// that fit in the return message.</param>
+        /// <param name ="metadataFromBlob">Specifies whether to fetch backup metadata from the backup blob in the
+        /// response.</param>
         /// <param name ="cancellationToken">Cancels the client-side operation.</param>
         /// <returns>
         /// A task that represents the asynchronous operation.
@@ -538,6 +543,7 @@ namespace Microsoft.ServiceFabric.Client
             DateTime? endDateTimeFilter = default(DateTime?),
             ContinuationToken continuationToken = default(ContinuationToken),
             long? maxResults = 0,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -698,6 +704,8 @@ namespace Microsoft.ServiceFabric.Client
         /// <param name ="endDateTimeFilter">Specify the end date time till which to enumerate backups, in datetime format. The
         /// date time must be specified in ISO8601 format. This is an optional parameter. If not specified, enumeration is done
         /// till the most recent backup.</param>
+        /// <param name ="metadataFromBlob">Specifies whether to fetch backup metadata from the backup blob in the
+        /// response.</param>
         /// <param name ="cancellationToken">Cancels the client-side operation.</param>
         /// <returns>
         /// A task that represents the asynchronous operation.
@@ -712,6 +720,7 @@ namespace Microsoft.ServiceFabric.Client
             bool? latest = false,
             DateTime? startDateTimeFilter = default(DateTime?),
             DateTime? endDateTimeFilter = default(DateTime?),
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -846,6 +855,8 @@ namespace Microsoft.ServiceFabric.Client
         /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.</param>
+        /// <param name ="metadataFromBlob">Specifies whether to fetch backup metadata from the backup blob in the
+        /// response.</param>
         /// <param name ="cancellationToken">Cancels the client-side operation.</param>
         /// <returns>
         /// A task that represents the asynchronous operation.
@@ -860,6 +871,7 @@ namespace Microsoft.ServiceFabric.Client
             bool? latest = false,
             int? restoreTimeout = 10,
             long? serverTimeout = 60,
+            bool? metadataFromBlob = false,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Common/Generated/BackupPolicyDescription.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/BackupPolicyDescription.cs
@@ -29,10 +29,10 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="schedule">Describes the backup schedule parameters.</param>
         /// <param name="storage">Describes the details of backup storage where to store the periodic backups.</param>
         /// <param name="retentionPolicy">Describes the policy to retain backups in storage.</param>
-        /// <param name="compressionStrategy">Specifies the compression strategy to be used for backups. Default is ZIP.
-        /// Possible values include: 'ZIP', 'ZSTANDARD'</param>
-        /// <param name="quickRecovery">Specifies whether to enable quick recovery for this backup policy. When enabled, allows
-        /// for faster restore operations at the cost of additional storage overhead. Default is false.</param>
+        /// <param name="compressionType">Specifies the compression type to be used for backups. Default is CLUSTER_DEFINED.
+        /// Possible values include: 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'</param>
+        /// <param name="quickRecovery">Specifies the quick recovery strategy for this backup policy. Default is Disabled.
+        /// Possible values include: 'Disabled', 'FromPrimary'</param>
         public BackupPolicyDescription(
             string name,
             bool? autoRestoreOnDataLoss,
@@ -40,8 +40,8 @@ namespace Microsoft.ServiceFabric.Common
             BackupScheduleDescription schedule,
             BackupStorageDescription storage,
             RetentionPolicyDescription retentionPolicy = default(RetentionPolicyDescription),
-            CompressionStrategy? compressionStrategy = default(CompressionStrategy?),
-            bool? quickRecovery = default(bool?))
+            CompressionType? compressionType = default(CompressionType?),
+            QuickRecovery? quickRecovery = default(QuickRecovery?))
         {
             name.ThrowIfNull(nameof(name));
             autoRestoreOnDataLoss.ThrowIfNull(nameof(autoRestoreOnDataLoss));
@@ -55,7 +55,7 @@ namespace Microsoft.ServiceFabric.Common
             this.Schedule = schedule;
             this.Storage = storage;
             this.RetentionPolicy = retentionPolicy;
-            this.CompressionStrategy = compressionStrategy;
+            this.CompressionType = compressionType;
             this.QuickRecovery = quickRecovery;
         }
 
@@ -96,15 +96,15 @@ namespace Microsoft.ServiceFabric.Common
         public RetentionPolicyDescription RetentionPolicy { get; }
 
         /// <summary>
-        /// Gets specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP',
-        /// 'ZSTANDARD'
+        /// Gets specifies the compression type to be used for backups. Default is CLUSTER_DEFINED. Possible values include:
+        /// 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'
         /// </summary>
-        public CompressionStrategy? CompressionStrategy { get; }
+        public CompressionType? CompressionType { get; }
 
         /// <summary>
-        /// Gets specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore
-        /// operations at the cost of additional storage overhead. Default is false.
+        /// Gets specifies the quick recovery strategy for this backup policy. Default is Disabled. Possible values include:
+        /// 'Disabled', 'FromPrimary'
         /// </summary>
-        public bool? QuickRecovery { get; }
+        public QuickRecovery? QuickRecovery { get; }
     }
 }

--- a/src/Microsoft.ServiceFabric.Common/Generated/BackupPolicyDescription.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/BackupPolicyDescription.cs
@@ -29,13 +29,19 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="schedule">Describes the backup schedule parameters.</param>
         /// <param name="storage">Describes the details of backup storage where to store the periodic backups.</param>
         /// <param name="retentionPolicy">Describes the policy to retain backups in storage.</param>
+        /// <param name="compressionStrategy">Specifies the compression strategy to be used for backups. Default is ZIP.
+        /// Possible values include: 'ZIP', 'ZSTANDARD'</param>
+        /// <param name="quickRecovery">Specifies whether to enable quick recovery for this backup policy. When enabled, allows
+        /// for faster restore operations at the cost of additional storage overhead. Default is false.</param>
         public BackupPolicyDescription(
             string name,
             bool? autoRestoreOnDataLoss,
             int? maxIncrementalBackups,
             BackupScheduleDescription schedule,
             BackupStorageDescription storage,
-            RetentionPolicyDescription retentionPolicy = default(RetentionPolicyDescription))
+            RetentionPolicyDescription retentionPolicy = default(RetentionPolicyDescription),
+            CompressionStrategy? compressionStrategy = default(CompressionStrategy?),
+            bool? quickRecovery = default(bool?))
         {
             name.ThrowIfNull(nameof(name));
             autoRestoreOnDataLoss.ThrowIfNull(nameof(autoRestoreOnDataLoss));
@@ -49,6 +55,8 @@ namespace Microsoft.ServiceFabric.Common
             this.Schedule = schedule;
             this.Storage = storage;
             this.RetentionPolicy = retentionPolicy;
+            this.CompressionStrategy = compressionStrategy;
+            this.QuickRecovery = quickRecovery;
         }
 
         /// <summary>
@@ -86,5 +94,17 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets the policy to retain backups in storage.
         /// </summary>
         public RetentionPolicyDescription RetentionPolicy { get; }
+
+        /// <summary>
+        /// Gets specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP',
+        /// 'ZSTANDARD'
+        /// </summary>
+        public CompressionStrategy? CompressionStrategy { get; }
+
+        /// <summary>
+        /// Gets specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore
+        /// operations at the cost of additional storage overhead. Default is false.
+        /// </summary>
+        public bool? QuickRecovery { get; }
     }
 }

--- a/src/Microsoft.ServiceFabric.Common/Generated/CompressionStrategy.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/CompressionStrategy.cs
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for CompressionStrategy.
+    /// </summary>
+    public enum CompressionStrategy
+    {
+        /// <summary>
+        /// Use ZIP compression for backups.
+        /// </summary>
+        ZIP,
+
+        /// <summary>
+        /// Use Zstandard compression for backups, which provides better compression ratios.
+        /// </summary>
+        ZSTANDARD,
+    }
+}

--- a/src/Microsoft.ServiceFabric.Common/Generated/CompressionType.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/CompressionType.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for CompressionType.
+    /// </summary>
+    public enum CompressionType
+    {
+        /// <summary>
+        /// Use the cluster-defined compression method for backups.
+        /// </summary>
+        CLUSTER_DEFINED,
+
+        /// <summary>
+        /// Use ZIP compression for backups.
+        /// </summary>
+        ZIP,
+
+        /// <summary>
+        /// Use Zstandard compression for backups, which provides better compression ratios.
+        /// </summary>
+        ZSTANDARD,
+    }
+}

--- a/src/Microsoft.ServiceFabric.Common/Generated/QuickRecovery.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/QuickRecovery.cs
@@ -16,8 +16,8 @@ namespace Microsoft.ServiceFabric.Common
         Disabled,
 
         /// <summary>
-        /// Recover from primary replica when primary has newer or equal data. Require manual intervention when backup has
-        /// newer data.
+        /// Recover from primary replica when primary has newer or equal data in case of Partial Data Loss. Requires manual
+        /// intervention when backup has newer data.
         /// </summary>
         FromPrimary,
     }

--- a/src/Microsoft.ServiceFabric.Common/Generated/QuickRecovery.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/QuickRecovery.cs
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for QuickRecovery.
+    /// </summary>
+    public enum QuickRecovery
+    {
+        /// <summary>
+        /// Quick Recovery is disabled. Use normal restore process with manual intervention.
+        /// </summary>
+        Disabled,
+
+        /// <summary>
+        /// Recover from primary replica when primary has newer or equal data. Require manual intervention when backup has
+        /// newer data.
+        /// </summary>
+        FromPrimary,
+    }
+}

--- a/src/Microsoft.ServiceFabric.Common/Generated/RestoreProgressInfo.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/RestoreProgressInfo.cs
@@ -17,7 +17,8 @@ namespace Microsoft.ServiceFabric.Common
         /// Initializes a new instance of the RestoreProgressInfo class.
         /// </summary>
         /// <param name="restoreState">Represents the current state of the partition restore operation.
-        /// . Possible values include: 'Invalid', 'Accepted', 'RestoreInProgress', 'Success', 'Failure', 'Timeout'</param>
+        /// . Possible values include: 'Invalid', 'Accepted', 'RestoreInProgress', 'SecondariesInProgress', 'Success',
+        /// 'Failure', 'Timeout'</param>
         /// <param name="timeStampUtc">Timestamp when operation succeeded or failed.</param>
         /// <param name="restoredEpoch">Describes the epoch at which the partition is restored.</param>
         /// <param name="restoredLsn">Restored LSN.</param>
@@ -38,7 +39,8 @@ namespace Microsoft.ServiceFabric.Common
 
         /// <summary>
         /// Gets represents the current state of the partition restore operation.
-        /// . Possible values include: 'Invalid', 'Accepted', 'RestoreInProgress', 'Success', 'Failure', 'Timeout'
+        /// . Possible values include: 'Invalid', 'Accepted', 'RestoreInProgress', 'SecondariesInProgress', 'Success',
+        /// 'Failure', 'Timeout'
         /// </summary>
         public RestoreState? RestoreState { get; }
 

--- a/src/Microsoft.ServiceFabric.Common/Generated/RestoreState.cs
+++ b/src/Microsoft.ServiceFabric.Common/Generated/RestoreState.cs
@@ -26,6 +26,11 @@ namespace Microsoft.ServiceFabric.Common
         RestoreInProgress,
 
         /// <summary>
+        /// Restore operation for secondary replicas has been triggered and is under process.
+        /// </summary>
+        SecondariesInProgress,
+
+        /// <summary>
         /// Operation completed with success.
         /// </summary>
         Success,

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetApplicationBackupListCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetApplicationBackupListCmdlet.cs
@@ -67,6 +67,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         [Parameter(Mandatory = false, Position = 5)]
         public long? MaxResults { get; set; }
 
+        /// <summary>
+        /// Gets or sets MetadataFromBlob. Specifies whether to fetch backup metadata from the backup blob in the response.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 6)]
+        public bool? MetadataFromBlob { get; set; }
+
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
@@ -81,6 +87,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     endDateTimeFilter: this.EndDateTimeFilter,
                     continuationToken: continuationToken,
                     maxResults: this.MaxResults,
+                    metadataFromBlob: this.MetadataFromBlob,
                     cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
 
                 if (result == null)

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetPartitionBackupListCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetPartitionBackupListCmdlet.cs
@@ -53,6 +53,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         [Parameter(Mandatory = false, Position = 4)]
         public DateTime? EndDateTimeFilter { get; set; }
 
+        /// <summary>
+        /// Gets or sets MetadataFromBlob. Specifies whether to fetch backup metadata from the backup blob in the response.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 5)]
+        public bool? MetadataFromBlob { get; set; }
+
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
@@ -65,6 +71,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     latest: this.Latest,
                     startDateTimeFilter: this.StartDateTimeFilter,
                     endDateTimeFilter: this.EndDateTimeFilter,
+                    metadataFromBlob: this.MetadataFromBlob,
                     cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
 
                 if (result == null)

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetServiceBackupListCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/GetServiceBackupListCmdlet.cs
@@ -67,6 +67,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         [Parameter(Mandatory = false, Position = 5)]
         public long? MaxResults { get; set; }
 
+        /// <summary>
+        /// Gets or sets MetadataFromBlob. Specifies whether to fetch backup metadata from the backup blob in the response.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 6)]
+        public bool? MetadataFromBlob { get; set; }
+
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
@@ -81,6 +87,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     endDateTimeFilter: this.EndDateTimeFilter,
                     continuationToken: continuationToken,
                     maxResults: this.MaxResults,
+                    metadataFromBlob: this.MetadataFromBlob,
                     cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
 
                 if (result == null)

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/NewBackupPolicyCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/NewBackupPolicyCmdlet.cs
@@ -259,18 +259,18 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public int? MinimumNumberOfBackups { get; set; }
 
         /// <summary>
-        /// Gets or sets CompressionStrategy. Specifies the compression strategy to be used for backups. Default is ZIP.
-        /// Possible values include: 'ZIP', 'ZSTANDARD'
+        /// Gets or sets CompressionType. Specifies the compression type to be used for backups. Default is CLUSTER_DEFINED.
+        /// Possible values include: 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'
         /// </summary>
         [Parameter(Mandatory = false, Position = 24)]
-        public CompressionStrategy? CompressionStrategy { get; set; }
+        public CompressionType? CompressionType { get; set; }
 
         /// <summary>
-        /// Gets or sets QuickRecovery. Specifies whether to enable quick recovery for this backup policy. When enabled, allows
-        /// for faster restore operations at the cost of additional storage overhead. Default is false.
+        /// Gets or sets QuickRecovery. Specifies the quick recovery strategy for this backup policy. Default is Disabled.
+        /// Possible values include: 'Disabled', 'FromPrimary'
         /// </summary>
         [Parameter(Mandatory = false, Position = 25)]
-        public bool? QuickRecovery { get; set; }
+        public QuickRecovery? QuickRecovery { get; set; }
 
         /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
@@ -354,7 +354,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             schedule: backupScheduleDescription,
             storage: backupStorageDescription,
             retentionPolicy: retentionPolicyDescription,
-            compressionStrategy: this.CompressionStrategy,
+            compressionType: this.CompressionType,
             quickRecovery: this.QuickRecovery);
 
             this.ServiceFabricClient.BackupRestore.CreateBackupPolicyAsync(

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/NewBackupPolicyCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/NewBackupPolicyCmdlet.cs
@@ -259,18 +259,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public int? MinimumNumberOfBackups { get; set; }
 
         /// <summary>
+        /// Gets or sets CompressionStrategy. Specifies the compression strategy to be used for backups. Default is ZIP.
+        /// Possible values include: 'ZIP', 'ZSTANDARD'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 24)]
+        public CompressionStrategy? CompressionStrategy { get; set; }
+
+        /// <summary>
+        /// Gets or sets QuickRecovery. Specifies whether to enable quick recovery for this backup policy. When enabled, allows
+        /// for faster restore operations at the cost of additional storage overhead. Default is false.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 25)]
+        public bool? QuickRecovery { get; set; }
+
+        /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24)]
+        [Parameter(Mandatory = false, Position = 26)]
         public long? ServerTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets ValidateConnection. Specifies whether to validate the storage connection and credentials before
         /// creating or updating the backup policies.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25)]
+        [Parameter(Mandatory = false, Position = 27)]
         public bool? ValidateConnection { get; set; }
 
         /// <inheritdoc/>
@@ -339,7 +353,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             maxIncrementalBackups: this.MaxIncrementalBackups,
             schedule: backupScheduleDescription,
             storage: backupStorageDescription,
-            retentionPolicy: retentionPolicyDescription);
+            retentionPolicy: retentionPolicyDescription,
+            compressionStrategy: this.CompressionStrategy,
+            quickRecovery: this.QuickRecovery);
 
             this.ServiceFabricClient.BackupRestore.CreateBackupPolicyAsync(
                 backupPolicyDescription: backupPolicyDescription,

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/RestorePartitionCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/RestorePartitionCmdlet.cs
@@ -161,6 +161,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         [Parameter(Mandatory = false, Position = 18)]
         public long? ServerTimeout { get; set; }
 
+        /// <summary>
+        /// Gets or sets MetadataFromBlob. Specifies whether to fetch backup metadata from the backup blob in the response.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 19)]
+        public bool? MetadataFromBlob { get; set; }
+
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
@@ -210,6 +216,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                 latest: this.Latest,
                 restoreTimeout: this.RestoreTimeout,
                 serverTimeout: this.ServerTimeout,
+                metadataFromBlob: this.MetadataFromBlob,
                 cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
 
             Console.WriteLine("Success!");

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/UpdateBackupPolicyCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/UpdateBackupPolicyCmdlet.cs
@@ -265,18 +265,18 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public int? MinimumNumberOfBackups { get; set; }
 
         /// <summary>
-        /// Gets or sets CompressionStrategy. Specifies the compression strategy to be used for backups. Default is ZIP.
-        /// Possible values include: 'ZIP', 'ZSTANDARD'
+        /// Gets or sets CompressionType. Specifies the compression type to be used for backups. Default is CLUSTER_DEFINED.
+        /// Possible values include: 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'
         /// </summary>
         [Parameter(Mandatory = false, Position = 25)]
-        public CompressionStrategy? CompressionStrategy { get; set; }
+        public CompressionType? CompressionType { get; set; }
 
         /// <summary>
-        /// Gets or sets QuickRecovery. Specifies whether to enable quick recovery for this backup policy. When enabled, allows
-        /// for faster restore operations at the cost of additional storage overhead. Default is false.
+        /// Gets or sets QuickRecovery. Specifies the quick recovery strategy for this backup policy. Default is Disabled.
+        /// Possible values include: 'Disabled', 'FromPrimary'
         /// </summary>
         [Parameter(Mandatory = false, Position = 26)]
-        public bool? QuickRecovery { get; set; }
+        public QuickRecovery? QuickRecovery { get; set; }
 
         /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
@@ -360,7 +360,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             schedule: backupScheduleDescription,
             storage: backupStorageDescription,
             retentionPolicy: retentionPolicyDescription,
-            compressionStrategy: this.CompressionStrategy,
+            compressionType: this.CompressionType,
             quickRecovery: this.QuickRecovery);
 
             this.ServiceFabricClient.BackupRestore.UpdateBackupPolicyAsync(

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/UpdateBackupPolicyCmdlet.cs
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/UpdateBackupPolicyCmdlet.cs
@@ -265,18 +265,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public int? MinimumNumberOfBackups { get; set; }
 
         /// <summary>
+        /// Gets or sets CompressionStrategy. Specifies the compression strategy to be used for backups. Default is ZIP.
+        /// Possible values include: 'ZIP', 'ZSTANDARD'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 25)]
+        public CompressionStrategy? CompressionStrategy { get; set; }
+
+        /// <summary>
+        /// Gets or sets QuickRecovery. Specifies whether to enable quick recovery for this backup policy. When enabled, allows
+        /// for faster restore operations at the cost of additional storage overhead. Default is false.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 26)]
+        public bool? QuickRecovery { get; set; }
+
+        /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25)]
+        [Parameter(Mandatory = false, Position = 27)]
         public long? ServerTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets ValidateConnection. Specifies whether to validate the storage connection and credentials before
         /// creating or updating the backup policies.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26)]
+        [Parameter(Mandatory = false, Position = 28)]
         public bool? ValidateConnection { get; set; }
 
         /// <inheritdoc/>
@@ -345,7 +359,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             maxIncrementalBackups: this.MaxIncrementalBackups,
             schedule: backupScheduleDescription,
             storage: backupStorageDescription,
-            retentionPolicy: retentionPolicyDescription);
+            retentionPolicy: retentionPolicyDescription,
+            compressionStrategy: this.CompressionStrategy,
+            quickRecovery: this.QuickRecovery);
 
             this.ServiceFabricClient.BackupRestore.UpdateBackupPolicyAsync(
                 backupPolicyDescription: backupPolicyDescription,

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -16073,6 +16073,30 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="21">
+                <maml:name>CompressionStrategy</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP', 'ZSTANDARD'
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">CompressionStrategy?</command:parameterValue>
+                <dev:type>
+                    <maml:name>CompressionStrategy?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="22">
+                <maml:name>QuickRecovery</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore operations at the cost of additional storage overhead. Default is false.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="23">
                 <maml:name>ServerTimeout</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -16084,7 +16108,7 @@
                     <maml:name>long?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="22">
+            <command:parameter required="false" position="24">
                 <maml:name>ValidateConnection</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -16751,6 +16775,30 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="22">
+                <maml:name>CompressionStrategy</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP', 'ZSTANDARD'
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">CompressionStrategy?</command:parameterValue>
+                <dev:type>
+                    <maml:name>CompressionStrategy?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="23">
+                <maml:name>QuickRecovery</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore operations at the cost of additional storage overhead. Default is false.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="24">
                 <maml:name>ServerTimeout</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -16762,7 +16810,7 @@
                     <maml:name>long?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="23">
+            <command:parameter required="false" position="25">
                 <maml:name>ValidateConnection</maml:name>
                 <maml:Description>
                     <maml:para>

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -16073,27 +16073,27 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="21">
-                <maml:name>CompressionStrategy</maml:name>
+                <maml:name>CompressionType</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP', 'ZSTANDARD'
+                    Specifies the compression type to be used for backups. Default is CLUSTER_DEFINED. Possible values include: 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">CompressionStrategy?</command:parameterValue>
+            <command:parameterValue required="false">CompressionType?</command:parameterValue>
                 <dev:type>
-                    <maml:name>CompressionStrategy?</maml:name>
+                    <maml:name>CompressionType?</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="22">
                 <maml:name>QuickRecovery</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore operations at the cost of additional storage overhead. Default is false.
+                    Specifies the quick recovery strategy for this backup policy. Default is Disabled. Possible values include: 'Disabled', 'FromPrimary'
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">bool?</command:parameterValue>
+            <command:parameterValue required="false">QuickRecovery?</command:parameterValue>
                 <dev:type>
-                    <maml:name>bool?</maml:name>
+                    <maml:name>QuickRecovery?</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="23">
@@ -16775,27 +16775,27 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="22">
-                <maml:name>CompressionStrategy</maml:name>
+                <maml:name>CompressionType</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Specifies the compression strategy to be used for backups. Default is ZIP. Possible values include: 'ZIP', 'ZSTANDARD'
+                    Specifies the compression type to be used for backups. Default is CLUSTER_DEFINED. Possible values include: 'CLUSTER_DEFINED', 'ZIP', 'ZSTANDARD'
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">CompressionStrategy?</command:parameterValue>
+            <command:parameterValue required="false">CompressionType?</command:parameterValue>
                 <dev:type>
-                    <maml:name>CompressionStrategy?</maml:name>
+                    <maml:name>CompressionType?</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="23">
                 <maml:name>QuickRecovery</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Specifies whether to enable quick recovery for this backup policy. When enabled, allows for faster restore operations at the cost of additional storage overhead. Default is false.
+                    Specifies the quick recovery strategy for this backup policy. Default is Disabled. Possible values include: 'Disabled', 'FromPrimary'
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">bool?</command:parameterValue>
+            <command:parameterValue required="false">QuickRecovery?</command:parameterValue>
                 <dev:type>
-                    <maml:name>bool?</maml:name>
+                    <maml:name>QuickRecovery?</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="24">
@@ -17085,6 +17085,18 @@
             <command:parameterValue required="false">long?</command:parameterValue>
                 <dev:type>
                     <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="6">
+                <maml:name>MetadataFromBlob</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to fetch backup metadata from the backup blob in the response.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
                 </dev:type>
             </command:parameter>
             </command:parameters>
@@ -17441,6 +17453,18 @@
                     <maml:name>long?</maml:name>
                 </dev:type>
             </command:parameter>
+            <command:parameter required="false" position="6">
+                <maml:name>MetadataFromBlob</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to fetch backup metadata from the backup blob in the response.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
+                </dev:type>
+            </command:parameter>
             </command:parameters>
     </command:command>
     <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
@@ -17757,6 +17781,18 @@
             <command:parameterValue required="false">DateTime?</command:parameterValue>
                 <dev:type>
                     <maml:name>DateTime?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="5">
+                <maml:name>MetadataFromBlob</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to fetch backup metadata from the backup blob in the response.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
                 </dev:type>
             </command:parameter>
             </command:parameters>
@@ -18419,6 +18455,18 @@
             <command:parameterValue required="false">long?</command:parameterValue>
                 <dev:type>
                     <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="18">
+                <maml:name>MetadataFromBlob</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies whether to fetch backup metadata from the backup blob in the response.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">bool?</command:parameterValue>
+                <dev:type>
+                    <maml:name>bool?</maml:name>
                 </dev:type>
             </command:parameter>
             </command:parameters>


### PR DESCRIPTION

**Add compression, restore state, and metadata flag**

This PR introduces three key changes in Sf-SWAgger:

- BackupPolicy: Added optional parameters CompressionType and QuickRecovery.

- Restore: Added new state SecondaryInProgress to indicate that restore is still ongoing on secondary replicas after primary completes.

- Query Param: Introduced MetadataFromBlobOptionalQueryParam (boolean) to control whether backup metadata is fetched from the backup blob in the response.

These changes improve flexibility in backup policies, provide better restore progress visibility, and allow customers to optimize metadata fetch behavior.

BackupPolicy Changes ( native & managed code)  PR  :
https://msazure.visualstudio.com/One/_git/WindowsFabric/pullrequest/12848983


QueryParam change PR : (https://msazure.visualstudio.com/One/_git/WindowsFabric/pullrequest/9280568)

RestoreState change PR : ( https://msazure.visualstudio.com/One/_git/WindowsFabric/pullrequest/11707675 )

<img width="1036" height="401" alt="image" src="https://github.com/user-attachments/assets/4f6ccf93-309c-4fce-b5b0-a387b4b45773" />


Increment the minor version because the Policy is Backward compatible with two optional field 