### PR TITLE
Remove usage of suspicious System.Management.Automation.dll

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -23,7 +23,7 @@
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>5</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-06" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0 " />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>  
   <ItemGroup>
     <Reference Include="SfSbzYamlMergeLib">

--- a/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
+++ b/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />
+    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
+++ b/src/netframework/Microsoft.ServiceFabric.Powershell.Http/Microsoft.ServiceFabric.Powershell.Http_netframework.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Addressing Component Governance compliance - [link.](https://msazure.visualstudio.com/One/_componentGovernance/service-fabric-client-dotnet/alert/12636986?typeId=26654533&pipelinesTrackingFilter=0)

Old NuGet package **System.Management.Automation.dll.10.0.10586** was not a package owned by Microsoft organization on NuGet.org and is deprecated and unlisted right now.
This package was used to circumvent the fact that **System.Management.Automation** nuget was not supported on `.net462`. **PowerShellStandard.Library.5.1.1** nuget on the other hand is owned by Microsoft and PowerShell team.

After inspection of the contents of the suspicious package as well as the contents of the **PowerShellStandard.Library.5.1.1** it turns out they both have the same `System.Management.Automation.dll`.

For reference:
New **PowerShellStandard.Library.5.1.1**
<img width="1145" height="717" alt="image" src="https://github.com/user-attachments/assets/785248a5-15b6-497f-828f-174a9d4b2dce" />

Old **System.Management.Automation.dll.10.0.10586**
<img width="1015" height="717" alt="image" src="https://github.com/user-attachments/assets/26c057df-13c9-4a6c-8ef9-aecb27c90874" />
