### PR TITLE
Bump Powershell module version to 1.10.0

### DIFF
--- a/src/Microsoft.ServiceFabric.Powershell.Http/manifest/Microsoft.ServiceFabric.Powershell.Http.psd1
+++ b/src/Microsoft.ServiceFabric.Powershell.Http/manifest/Microsoft.ServiceFabric.Powershell.Http.psd1
@@ -19,7 +19,7 @@
     }
 
 # Version number of this module. Minor.Patch version matches the Major.Minor version of client lib.
-ModuleVersion = '1.9.0'
+ModuleVersion = '1.10.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'


### PR DESCRIPTION
Bumping powershell module's minor version up to 10 (now 1.10.0) so a new PS module can be published. 